### PR TITLE
Fix puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,20 @@ These programs should render some output that should all fit into some dimension
 
 #### 3. Taking screenshots
 
-For each program a Chromium instance will navigate to it and take a screenshot of the output. These screenshots are then made into a series of responsive images - the full size screenshot is the 3x version, and a smaller 2x and 1x version is made. These are then written to disk.
+For each program a headless Chrome instance (driven by [Puppeteer](https://pptr.dev)) will navigate to it and take a screenshot of the output. These screenshots are then made into a series of responsive images - the full size screenshot is the 3x version, and a smaller 2x and 1x version is made. These are then written to disk.
+
+Puppeteer downloads its own up-to-date Chrome on install, so no system browser is required. Screenshots are taken with `--no-sandbox` so that they work in CI environments that run as root. If you'd rather use a browser already installed on the machine, set the `PUPPETEER_EXECUTABLE_PATH` environment variable to point at it:
+
+```sh
+PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable elm-example-publisher
+```
 
 **Customized with:**
 
 - `--output-dir <dir>` tells it where to write the output files
 - `--no-screenshots` will skip this step. Not all example websites are visual and need screenshots.
 - `--width <pixels>` and `--height <pixels>` set the dimensions of the screenshots (defaults to 990x504.)
-- `--debug` runs Chromium visibly so you can see what is going on
+- `--debug` runs Chrome visibly so you can see what is going on
 
 #### 4. Publishing Ellies
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-example-publisher",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "bin": "src/cli.js",
   "description": "Create a beautiful example website for your Elm project",
   "main": "index.js",
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/gampleman/elm-example-publisher#readme",
   "dependencies": {
-    "capture-website": "^1.0.0",
     "chalk": "^4.1.0",
     "commander": "^5.1.0",
     "copy-dir": "^1.3.0",
@@ -37,6 +36,7 @@
     "natives": "^1.1.6",
     "node-elm-compiler": "^5.0.4",
     "node-fetch": "^2.6.0",
+    "puppeteer": "^24.10.0",
     "sharp": "^0.25.4",
     "static-server": "^2.2.1",
     "workbox-build": "^5.1.3"

--- a/src/screenshots.js
+++ b/src/screenshots.js
@@ -1,75 +1,101 @@
 const StaticServer = require("static-server"),
   path = require("path"),
-  captureWebsite = require("capture-website"),
+  puppeteer = require("puppeteer"),
   sharp = require("sharp"),
   log = require("./log");
 
-function snapPicture(
+// Launch flags that keep Chrome happy in CI: it commonly runs as root there,
+// where Chrome refuses to start without --no-sandbox. Modern puppeteer
+// downloads its own up-to-date Chrome for Testing, but PUPPETEER_EXECUTABLE_PATH
+// can still be used to point at a system-installed browser if desired.
+function launchBrowser(debug) {
+  const options = {
+    headless: !debug,
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  };
+  if (debug) {
+    options.slowMo = 100;
+  }
+  return puppeteer.launch(options);
+}
+
+async function snapPicture(
+  browser,
   outputDir,
   exampleDir,
   name,
-  output,
+  url,
   delay,
   width,
   height,
   debug
 ) {
   const dir = path.join(outputDir.absolute, exampleDir);
-  var bigPicture = path.join(dir, name + "@3x.png");
-  return captureWebsite
-    .file(output, bigPicture, {
-      inputType: "url",
-      scaleFactor: 1,
-      overwrite: true,
-      debug,
-      width,
-      height,
-      delay,
-    })
-    .then(function () {
-      log.generated(
-        path.join(outputDir.relative, exampleDir, name + "@3x.png")
-      );
-      var w = Math.floor(width / 3),
-        h = Math.floor(height / 3);
-      var resizer = sharp(bigPicture);
+  const bigPicture = path.join(dir, name + "@3x.png");
 
-      return Promise.all(
-        [1, 2]
-          .flatMap((factor) => {
-            const endName = name + (factor > 1 ? "@" + factor + "x" : "");
-            var fName = path.join(dir, endName + ".png");
-            var resized = resizer.clone().resize(w * factor, h * factor);
+  const page = await browser.newPage();
 
-            return [
-              resized
-                .clone()
-                .webp()
-                .toFile(path.join(dir, endName + ".webp")),
-
-              resized.toFile(fName).then(function () {
-                log.generated(
-                  path.join(outputDir.relative, exampleDir, endName + ".png")
-                );
-                log.generated(
-                  path.join(outputDir.relative, exampleDir, endName + ".webp")
-                );
-              }),
-            ];
-          })
-          .concat(
-            resizer
-              .clone()
-              .webp()
-              .toFile(path.join(dir, name + "@3x.webp"))
-              .then(() => {
-                log.generated(
-                  path.join(outputDir.relative, exampleDir, name + "@3x.webp")
-                );
-              })
-          )
-      );
+  if (debug) {
+    page.on("console", (message) => {
+      let { url, lineNumber, columnNumber } = message.location();
+      lineNumber = lineNumber ? `:${lineNumber}` : "";
+      columnNumber = columnNumber ? `:${columnNumber}` : "";
+      const location = url ? ` (${url}${lineNumber}${columnNumber})` : "";
+      console.log(`\nPage log:${location}\n${message.text()}\n`);
     });
+    page.on("pageerror", (error) => {
+      console.log("\nPage error:", error, "\n");
+    });
+  }
+
+  try {
+    await page.setViewport({ width, height, deviceScaleFactor: 1 });
+    await page.goto(url, { timeout: 60 * 1000, waitUntil: "networkidle2" });
+    if (delay) {
+      await new Promise((resolve) => setTimeout(resolve, delay * 1000));
+    }
+    await page.screenshot({ path: bigPicture });
+  } finally {
+    await page.close();
+  }
+
+  log.generated(path.join(outputDir.relative, exampleDir, name + "@3x.png"));
+  const w = Math.floor(width / 3),
+    h = Math.floor(height / 3);
+  const resizer = sharp(bigPicture);
+
+  return Promise.all(
+    [1, 2]
+      .flatMap((factor) => {
+        const endName = name + (factor > 1 ? "@" + factor + "x" : "");
+        const fName = path.join(dir, endName + ".png");
+        const resized = resizer.clone().resize(w * factor, h * factor);
+
+        return [
+          resized.clone().webp().toFile(path.join(dir, endName + ".webp")),
+
+          resized.toFile(fName).then(function () {
+            log.generated(
+              path.join(outputDir.relative, exampleDir, endName + ".png")
+            );
+            log.generated(
+              path.join(outputDir.relative, exampleDir, endName + ".webp")
+            );
+          }),
+        ];
+      })
+      .concat(
+        resizer
+          .clone()
+          .webp()
+          .toFile(path.join(dir, name + "@3x.webp"))
+          .then(() => {
+            log.generated(
+              path.join(outputDir.relative, exampleDir, name + "@3x.webp")
+            );
+          })
+      )
+  );
 }
 
 const runServer = (rootPath, cb) => {
@@ -87,26 +113,32 @@ const runServer = (rootPath, cb) => {
 
 module.exports = (examples, outputDir, debug) => {
   log.heading("Taking screenshots");
-  return runServer(outputDir.absolute, (baseUrl) =>
-    Promise.all(
-      examples.flatMap((example) => {
-        const snaps = ["preview", ...[example.tags.screenshot || []].flat()];
-        return snaps.map((snap) => {
-          const url = `${baseUrl}${example.basename}/iframe.html${
-            snap === "preview" ? "" : "#" + snap
-          }`;
-          return snapPicture(
-            outputDir,
-            example.basename,
-            snap,
-            url,
-            example.tags.delay || 0,
-            example.width,
-            example.height,
-            debug
-          );
-        });
-      })
-    )
-  );
+  return runServer(outputDir.absolute, async (baseUrl) => {
+    const browser = await launchBrowser(debug);
+    try {
+      return await Promise.all(
+        examples.flatMap((example) => {
+          const snaps = ["preview", ...[example.tags.screenshot || []].flat()];
+          return snaps.map((snap) => {
+            const url = `${baseUrl}${example.basename}/iframe.html${
+              snap === "preview" ? "" : "#" + snap
+            }`;
+            return snapPicture(
+              browser,
+              outputDir,
+              example.basename,
+              snap,
+              url,
+              example.tags.delay || 0,
+              example.width,
+              example.height,
+              debug
+            );
+          });
+        })
+      );
+    } finally {
+      await browser.close();
+    }
+  });
 };


### PR DESCRIPTION
## Problem

The screenshot step crashes on Netlify's new build image (Ubuntu 24.04 "noble"), breaking the elm-visualization docs builds. The failure is a cryptic `ECONNRESET` on Chrome's DevTools WebSocket:

```
message: 'connect ECONNRESET 127.0.0.1:39709'
_url: 'ws://127.0.0.1:39709/devtools/browser/...'
```

### Root cause

Screenshots went through `capture-website@1.x`, which transitively pins **`puppeteer@5.5.0` (2020)** and its bundled **Chromium revision 818858**. That ancient Chromium:
- no longer launches on newer Linux images (missing system libs on Ubuntu 24.04), and
- refuses to start as root (CI) without `--no-sandbox`.

`capture-website` is also **ESM-only from v2 onward**, so simply upgrading it would force a full ESM migration of this (CommonJS) package.

## Fix

Drop `capture-website` and drive **Puppeteer directly** (v24 — still CommonJS, requires node ≥18). Modern Puppeteer downloads its own current **Chrome for Testing**, which launches cleanly on recent Linux images and on Apple Silicon.

- Launch a **single shared headless browser** for the whole run instead of one Chromium per screenshot (this also kills the `MaxListenersExceededWarning` spam seen in the build logs).
- Always pass `--no-sandbox --disable-setuid-sandbox` for CI/root compatibility.
- Preserve existing behaviour: viewport sizing, `scaleFactor: 1` (sharp does the downscaling), `networkidle2` wait, `@delay` support, and `--debug` (visible browser + page console/error logging).
- `PUPPETEER_EXECUTABLE_PATH` is still honoured (read natively by Puppeteer) for using a system-installed browser instead of the downloaded one.

## Verification

Installed `puppeteer@^24.10.0` on node 19.5 and ran the new launch + screenshot path: launches **Chrome 148** with `--no-sandbox` and writes a valid PNG. (The old bundled Chromium is exactly what was crashing on Noble.)

## Compatibility

Major version bump (**2.0.0**) since the dependency set and Chrome-download-on-install behaviour change.
