### PR TITLE
Fix Netlify screenshots; add progress reporter (2.0.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 
 # TypeScript build output
 dist/
+*.tgz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-example-publisher",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "bin": "dist/cli.js",
   "description": "Create a beautiful example website for your Elm program examples",

--- a/src/borek/README.md
+++ b/src/borek/README.md
@@ -55,6 +55,23 @@ class Site extends Borek<{ dir: string }> {
 - `this.file(path)` / `this.glob(pattern)` — the underlying primitives, if you
   need to record a dependency without reading (e.g. a file another tool reads).
 
+## Reporting progress
+
+Pass a `reporter` in the config to observe the build as it runs. It receives a
+`start`/`finish`/`error` event (with timing) each time a real (non-cached) task
+executes — cache hits stay silent, so a no-op rebuild reports nothing. The
+built-in plumbing tasks (`input`/`file`/`glob` and the tracked-IO helpers) are
+filtered out, so you only see your own task methods:
+
+```ts
+new Site(options, {
+  store,
+  reporter: (e) => {
+    if (e.type === "finish") console.log(`done ${e.key.method} (${e.durationMs}ms)`);
+  },
+});
+```
+
 Under the hood this is driven by a lower-level functional core, `buildSystem`,
 which takes a `tasks` function of `(key, get) => value` (the class adapter turns
 each method into such a task). The `Volatile`, `File`, `Glob`, store, and watch

--- a/src/borek/borek.test.ts
+++ b/src/borek/borek.test.ts
@@ -222,3 +222,46 @@ test("readFile tracks the dependency without a separate declare call", async () 
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("a file change propagates through a tracking task to its dependents", async () => {
+  // Regression: a task that records file deps must return a value derived from
+  // those files (e.g. their hashes), not void. If it returns a constant, the
+  // engine early-exits ("value unchanged") when the file changes and dependents
+  // never re-run — which previously meant editing the template didn't rebuild
+  // pages.
+  const dir = await mkdtemp(join(tmpdir(), "borek-propagate-"));
+  const src = join(dir, "src.txt");
+  try {
+    await writeFile(src, "v1");
+    const log: string[] = [];
+    class T extends Borek<{ src: string }> {
+      // mimics trackElmModule: records a file dep, returns its hash so the value
+      // changes when the file does.
+      async track() {
+        const f = await this.file(await this.input("src"));
+        return f.hash;
+      }
+      async compile() {
+        log.push("compile");
+        await this.track();
+        return "output";
+      }
+    }
+    const store = inMemoryStore();
+    await new T({ src }, { store }).compile();
+    assert.deepEqual(log, ["compile"]);
+
+    // No change -> no recompile.
+    log.length = 0;
+    await new T({ src }, { store }).compile();
+    assert.deepEqual(log, []);
+
+    // Change the tracked file -> compile must re-run.
+    log.length = 0;
+    await writeFile(src, "v2");
+    await new T({ src }, { store }).compile();
+    assert.deepEqual(log, ["compile"], "file change must propagate to compile");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/borek/borek.ts
+++ b/src/borek/borek.ts
@@ -9,6 +9,7 @@ import {
   type Store,
   type Getter,
   type Invalidator,
+  type Reporter,
 } from "./engine.js";
 import {
   File,
@@ -26,6 +27,10 @@ import {
 export type BorekConfig = {
   store: Store;
   invalidator?: Invalidator;
+  // Receives a progress event each time a real (non-cached) task runs. The
+  // built-in plumbing tasks (input/file/glob and the tracked-IO helpers) are
+  // filtered out, so a reporter only sees the subclass's own task methods.
+  reporter?: Reporter;
 };
 
 // Per-instance internal state, kept in a WeakMap so it never collides with task
@@ -52,6 +57,11 @@ const RESERVED = new Set<string>([
   "copyFile",
   "globFiles",
 ]);
+
+// Built-in tasks that DO dispatch through the engine but are plumbing, not
+// user-meaningful work — filtered out of progress reporting so a reporter only
+// sees the subclass's own task methods.
+const BUILTIN_TASKS = new Set<string>(["input", "file", "glob"]);
 
 /**
  * Base class for a Borek build. Subclass it and define `async` methods — each
@@ -144,10 +154,18 @@ export class Borek<Input extends object = Record<string, never>> {
 const dispatch = (target: object, key: Key): Promise<unknown> => {
   const state = internals.get(target)!;
   if (state.record) return state.record(key);
+  const userReporter = state.config.reporter;
+  // Filter built-in plumbing tasks out of progress events.
+  const reporter: Reporter | undefined = userReporter
+    ? (event) => {
+        if (!BUILTIN_TASKS.has(event.key.method)) userReporter(event);
+      }
+    : undefined;
   return buildSystem({
     tasks: makeTasks(target),
     store: state.config.store,
     invalidator: state.config.invalidator ?? invalidateChangedFiles,
+    reporter,
   })(key);
 };
 

--- a/src/borek/engine.ts
+++ b/src/borek/engine.ts
@@ -30,6 +30,15 @@ export type Getter = (key: Key) => Promise<unknown>;
 export type Tasks = (key: Key, get: Getter) => Promise<unknown>;
 export type Invalidator = (store: Store) => unknown | Promise<unknown>;
 
+// Progress events emitted as the build runs. A Reporter receives these and can
+// render them however it likes (the package layer turns them into log lines).
+export type BuildEvent =
+  | { type: "start"; key: Key }
+  | { type: "finish"; key: Key; durationMs: number }
+  | { type: "error"; key: Key; durationMs: number; error: unknown };
+
+export type Reporter = (event: BuildEvent) => void;
+
 // A wrapper marking a value as non-deterministic: a task returning Volatile is
 // reconsidered on every run, but downstream tasks still early-exit if its value
 // is stable. At the type level it is the identity — the engine unwraps it
@@ -87,10 +96,11 @@ const recomputeForVerification = async (
   key: Key,
   fn: Tasks,
   previousValue: unknown,
+  reporter: Reporter | undefined,
 ): Promise<boolean> => {
   try {
     const result = await guardRunning(key, "execute", () =>
-      execute(store, guardRunning, key, fn),
+      execute(store, guardRunning, key, fn, reporter),
     );
     return !isDeepStrictEqual(normalizeResult(result), previousValue);
   } catch {
@@ -103,13 +113,14 @@ const executeMissingDependencies = async (
   guardRunning: GuardRunning,
   key: Key,
   fn: Tasks,
+  reporter: Reporter | undefined,
 ): Promise<boolean> => {
   const existing = store.get(key);
   if (existing && !existing.stale) {
     const results = await Promise.all(
       existing.dependencies.map((dep) =>
         guardRunning(dep, "executeMissingDependencies", () =>
-          executeMissingDependencies(store, guardRunning, dep, fn),
+          executeMissingDependencies(store, guardRunning, dep, fn, reporter),
         ),
       ),
     );
@@ -122,6 +133,7 @@ const executeMissingDependencies = async (
         key,
         fn,
         existing.value,
+        reporter,
       );
     }
     return false;
@@ -132,10 +144,11 @@ const executeMissingDependencies = async (
       key,
       fn,
       existing.value,
+      reporter,
     );
   } else {
     await guardRunning(key, "execute", () =>
-      execute(store, guardRunning, key, fn),
+      execute(store, guardRunning, key, fn, reporter),
     );
     return true;
   }
@@ -146,20 +159,40 @@ const execute = async (
   guardRunning: GuardRunning,
   key: Key,
   fn: Tasks,
+  reporter: Reporter | undefined,
 ): Promise<unknown> => {
   const dependencies: Key[] = [];
   const recorder: Getter = (newKey) => {
     dependencies.push(newKey);
-    return build(store, guardRunning, newKey, fn);
+    return build(store, guardRunning, newKey, fn, reporter);
   };
-  const result = await fn(key, recorder);
-  store.set(key, {
-    value: normalizeResult(result),
-    dependencies,
-    stale: false,
-    volatile: isVolatile(result),
-  });
-  return normalizeResult(result);
+  // A task reaching execute() is doing real work (not a cache hit), so this is
+  // where progress is reported. Timing is wall-clock for the task body.
+  const start = reporter ? performance.now() : 0;
+  if (reporter) reporter({ type: "start", key });
+  try {
+    const result = await fn(key, recorder);
+    if (reporter) {
+      reporter({ type: "finish", key, durationMs: performance.now() - start });
+    }
+    store.set(key, {
+      value: normalizeResult(result),
+      dependencies,
+      stale: false,
+      volatile: isVolatile(result),
+    });
+    return normalizeResult(result);
+  } catch (error) {
+    if (reporter) {
+      reporter({
+        type: "error",
+        key,
+        durationMs: performance.now() - start,
+        error,
+      });
+    }
+    throw error;
+  }
 };
 
 const build = async (
@@ -167,13 +200,14 @@ const build = async (
   guardRunning: GuardRunning,
   key: Key,
   fn: Tasks,
+  reporter: Reporter | undefined,
 ): Promise<unknown> => {
   if (!store.has(key)) {
     return await guardRunning(key, "execute", () =>
-      execute(store, guardRunning, key, fn),
+      execute(store, guardRunning, key, fn, reporter),
     );
   }
-  await executeMissingDependencies(store, guardRunning, key, fn);
+  await executeMissingDependencies(store, guardRunning, key, fn, reporter);
   return store.get(key)!.value;
 };
 
@@ -181,10 +215,11 @@ export type BuildConfig = {
   tasks: Tasks;
   store: Store;
   invalidator?: Invalidator;
+  reporter?: Reporter;
 };
 
 export const buildSystem =
-  ({ tasks, store, invalidator }: BuildConfig) =>
+  ({ tasks, store, invalidator, reporter }: BuildConfig) =>
   async (target: Key): Promise<unknown> => {
     // Volatile tasks are non-deterministic, so they must be reconsidered every
     // run; marking them stale (rather than always recomputing dependents) lets
@@ -195,7 +230,7 @@ export const buildSystem =
     if (invalidator) await invalidator(store);
     const guardRunning = running();
     try {
-      return await build(store, guardRunning, target, tasks);
+      return await build(store, guardRunning, target, tasks, reporter);
     } finally {
       await store.finalize();
     }

--- a/src/borek/index.ts
+++ b/src/borek/index.ts
@@ -15,6 +15,8 @@ export type {
   Getter,
   Invalidator,
   BuildConfig,
+  BuildEvent,
+  Reporter,
 } from "./engine.js";
 export {
   File,

--- a/src/borek/reporter.test.ts
+++ b/src/borek/reporter.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Borek, inMemoryStore, type BuildEvent } from "./index.js";
+
+const methods = (events: BuildEvent[], type: BuildEvent["type"]) =>
+  events.filter((e) => e.type === type).map((e) => e.key.method);
+
+test("reporter sees real tasks, not cache hits or built-ins", async () => {
+  const events: BuildEvent[] = [];
+  class Site extends Borek<{ n: number }> {
+    async main() {
+      return (await this.double()) + (await this.input("n"));
+    }
+    async double() {
+      return (await this.input("n")) * 2;
+    }
+  }
+  const store = inMemoryStore();
+  const site = new Site({ n: 5 }, { store, reporter: (e) => events.push(e) });
+
+  await site.main();
+  // First run: main + double execute; input() is a built-in and filtered out.
+  assert.deepEqual(methods(events, "start").sort(), ["double", "main"]);
+  assert.deepEqual(methods(events, "finish").sort(), ["double", "main"]);
+  assert.ok(!methods(events, "start").includes("input"), "built-ins filtered");
+
+  // Second run: everything cached -> no events.
+  events.length = 0;
+  await site.main();
+  assert.deepEqual(events, []);
+});
+
+test("reporter emits an error event when a task throws", async () => {
+  const events: BuildEvent[] = [];
+  class Failing extends Borek {
+    async main() {
+      return this.boom();
+    }
+    async boom(): Promise<never> {
+      throw new Error("kaboom");
+    }
+  }
+  const site = new Failing(
+    {},
+    { store: inMemoryStore(), reporter: (e) => events.push(e) },
+  );
+  await assert.rejects(site.main(), /kaboom/);
+  const errored = events
+    .filter((e) => e.type === "error")
+    .map((e) => e.key.method);
+  assert.ok(errored.includes("boom"), "boom reported as error");
+});
+
+test("finish events carry a non-negative duration", async () => {
+  const events: BuildEvent[] = [];
+  class Slow extends Borek {
+    async main() {
+      await new Promise((r) => setTimeout(r, 10));
+      return 1;
+    }
+  }
+  await new Slow(
+    {},
+    { store: inMemoryStore(), reporter: (e) => events.push(e) },
+  ).main();
+  const finish = events.find((e) => e.type === "finish");
+  assert.ok(finish && finish.type === "finish" && finish.durationMs >= 0);
+});

--- a/src/gather.ts
+++ b/src/gather.ts
@@ -22,9 +22,13 @@ export const exposesMain = (source: string): boolean => {
 const findElligibleFiles = async (
   inputDir: string,
 ): Promise<[string, string][]> => {
-  const files = await glob(inputDir + "/*.elm", {
-    windowsPathsNoEscape: true,
-  });
+  // Sort so the example order is deterministic: glob returns filesystem order,
+  // which is unstable across machines (macOS vs Linux CI) and even between runs.
+  // An unstable order would defeat incremental caching (every task sees a
+  // different examples list) and make the generated site's order nondeterministic.
+  const files = (
+    await glob(inputDir + "/*.elm", { windowsPathsNoEscape: true })
+  ).sort();
   const fileDetails = await Promise.all(
     files.map(
       async (file): Promise<[string, string]> => [

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import type { WatchEmitter } from "./borek/index.js";
 import { Site, type SiteRuntime } from "./site.js";
 import { startServer, launchBrowser } from "./screenshot.js";
 import { createSemaphore } from "./semaphore.js";
+import { createReporter } from "./reporter.js";
 import gather from "./gather.js";
 import publishEllies from "./publishEllies.js";
 import { startDevServer } from "./devServer.js";
@@ -61,6 +62,7 @@ const setup = async (
   const site = new Site(options, runtime, {
     store,
     invalidator: invalidateChangedFiles,
+    reporter: createReporter(),
   });
 
   const teardown = async () => {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -1,0 +1,51 @@
+import chalk from "chalk";
+import type { BuildEvent, Key, Reporter } from "./borek/index.js";
+
+// Turns a task key into a short human description for progress lines. Only the
+// user-meaningful tasks are described; anything else falls back to the method
+// name so new tasks still show up (just less prettily).
+const describe = (key: Key): string | null => {
+  const [arg] = key.args;
+  const example =
+    arg && typeof arg === "object" && "basename" in arg
+      ? String((arg as { basename: unknown }).basename)
+      : typeof arg === "string"
+        ? arg
+        : "";
+  // Allowlist: only the user-meaningful milestones get a line. Everything else
+  // (gather, parseExample, trackElmModule, prepareTemplate, the per-shot
+  // screenshot tasks, …) is plumbing and stays quiet, so the log reads as a
+  // list of "what got built" rather than internal task churn.
+  switch (key.method) {
+    case "buildExamplePage":
+      return `built ${example}`;
+    case "buildIndexPage":
+      return "built index page";
+    case "screenshots":
+      return `screenshotted ${example}`;
+    case "copyAssets":
+      return "copied assets";
+    default:
+      return null;
+  }
+};
+
+const formatDuration = (ms: number): string =>
+  ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
+
+// A plain-line progress reporter: one append-only line per finished task. Works
+// identically in an interactive terminal and in a CI log (no escape codes, no
+// in-place updates), which is what we want for debuggable build output.
+export const createReporter = (): Reporter => {
+  return (event: BuildEvent) => {
+    const label = describe(event.key);
+    if (label === null) return;
+    if (event.type === "finish") {
+      console.log(
+        `  ${chalk.green("✓")} ${label} ${chalk.dim(`(${formatDuration(event.durationMs)})`)}`,
+      );
+    } else if (event.type === "error") {
+      console.log(`  ${chalk.red("✗")} ${label} — ${chalk.red("failed")}`);
+    }
+  };
+};

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -62,15 +62,27 @@ export const startServer = (rootPath: string): Promise<RunningServer> =>
     });
   });
 
-// Launch flags that keep Chrome happy in CI (commonly runs as root, where Chrome
-// refuses to start without --no-sandbox). Puppeteer downloads its own Chrome;
-// PUPPETEER_EXECUTABLE_PATH can override it.
-export const launchBrowser = (debug: boolean): Promise<Browser> =>
-  puppeteer.launch({
-    headless: !debug,
+// Launch flags that keep Chrome happy in CI (commonly runs as root, where
+// Chrome refuses to start without --no-sandbox).
+//
+// headless: "shell" uses chrome-headless-shell, the lightweight headless build
+// purpose-made for screenshotting. Puppeteer >=22 defaults `headless: true` to
+// the *full* Chrome ("new" headless), which is much heavier — on constrained CI
+// (Netlify) that made every capture take ~70s. The old puppeteer-5 publisher
+// used the old light headless and was fast; "shell" restores that.
+// (debug mode launches headful so you can watch the browser.)
+// Puppeteer downloads its own Chrome; PUPPETEER_EXECUTABLE_PATH can override it.
+export const launchBrowser = async (debug: boolean): Promise<Browser> => {
+  const browser = await puppeteer.launch({
+    headless: debug ? false : "shell",
     args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    // Cap the protocol timeout so a stuck operation fails fast with a clear
+    // error rather than hanging at puppeteer's 180s default.
+    protocolTimeout: 90_000,
     ...(debug ? { slowMo: 100 } : {}),
   });
+  return browser;
+};
 
 type ImageFormat = "png" | "webp";
 
@@ -88,26 +100,37 @@ export async function snapPicture(
   debug: boolean,
 ): Promise<string> {
   const bigPicture = path.join(outputDir, exampleDir, name + "@3x.png");
-  const page = await browser.newPage();
 
-  if (debug) {
-    page.on("console", (message) => {
-      const { url: u, lineNumber } = message.location();
-      const loc = u ? ` (${u}${lineNumber ? `:${lineNumber}` : ""})` : "";
-      console.log(`\nPage log:${loc}\n${message.text()}\n`);
-    });
-    page.on("pageerror", (error) => console.log("\nPage error:", error, "\n"));
-  }
-
+  let page;
   try {
+    page = await browser.newPage();
+    if (debug) {
+      page.on("console", (message) => {
+        const { url: u, lineNumber } = message.location();
+        const loc = u ? ` (${u}${lineNumber ? `:${lineNumber}` : ""})` : "";
+        console.log(`\nPage log:${loc}\n${message.text()}\n`);
+      });
+      page.on("pageerror", (error) =>
+        console.log("\nPage error:", error, "\n"),
+      );
+    }
     await page.setViewport({ width, height, deviceScaleFactor: 1 });
-    await page.goto(url, { timeout: 60 * 1000, waitUntil: "networkidle2" });
+    // networkidle0 (zero in-flight connections), not networkidle2 (<=2): some
+    // examples fetch data in chained requests (geocode -> weather -> ...), and
+    // networkidle2 can fire in the gap between them, capturing a "Loading…"
+    // state. Waiting for fully-idle network lets those finish first.
+    await page.goto(url, { timeout: 45_000, waitUntil: "networkidle0" });
     if (delay) {
       await new Promise((resolve) => setTimeout(resolve, delay * 1000));
     }
     await page.screenshot({ path: bigPicture as `${string}.png` });
+  } catch (error) {
+    // Attribute failures to the specific page, which the bare puppeteer error
+    // doesn't do.
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to screenshot ${url}: ${message}`);
   } finally {
-    await page.close();
+    if (page) await page.close();
   }
   return bigPicture;
 }

--- a/src/site.ts
+++ b/src/site.ts
@@ -93,10 +93,17 @@ export class Site extends Borek<Options> {
   // Records a dependency on an Elm module and all of its transitive imports.
   // The Elm compiler reads these files itself, so we track them in parallel:
   // this is the one place tracking can't be folded into the read.
-  async trackElmModule(file: string): Promise<void> {
-    await this.file(file);
+  //
+  // Returns the files' content hashes (sorted by path). This matters: the value
+  // must change when any tracked file changes, otherwise a task that depends on
+  // trackElmModule would early-exit ("value unchanged") and never see the edit —
+  // e.g. editing the template wouldn't rebuild the pages.
+  async trackElmModule(file: string): Promise<string[]> {
     const dependencies = await findAllDependencies(file);
-    await Promise.all(dependencies.map((dep) => this.file(dep)));
+    const files = await Promise.all(
+      [file, ...dependencies].map((f) => this.file(f)),
+    );
+    return files.map((f) => `${f.path}:${f.hash ?? ""}`).sort();
   }
 
   async gatherAssets(): Promise<string[]> {


### PR DESCRIPTION
Fixes the examples-site build on Netlify's current build image and adds a progress reporter. Five commits, released as **2.0.2**.

## Fixes

1. **Screenshots on constrained CI** — `headless: "shell"` (chrome-headless-shell) instead of puppeteer 25's default full-Chrome headless, which made every capture take ~70s on Netlify and timed the build out. Also `waitUntil: "networkidle0"` (not `networkidle2`) so examples that chain HTTP fetches (e.g. WeatherRadial) aren't captured mid-load showing "Loading…".

2. **Template/source edits invalidate pages** — `trackElmModule` recorded file dependencies but returned `void`, so when a tracked file changed the engine early-exited ("value unchanged") and dependents never rebuilt — editing the template silently produced stale pages. It now returns the files' content hashes so invalidation propagates. (Engine regression test added.)

3. **Deterministic example order** — `gather()` returned examples in glob (filesystem) order, unstable across machines/runs. With `--ellie` feeding that list as the build's example set, every run differed, so the incremental cache was never reused and the generated site's order was nondeterministic. Now sorted by path.

## Feature: progress reporter

Borek can take a `reporter` in its config and emits start/finish/error events (with timing) for real, non-cached tasks; cache hits stay silent and built-in plumbing tasks are filtered out. The publisher uses it to print a plain-line "what got built" log that works the same locally and in CI — replacing the ad-hoc logging used during this debugging.

## Verification

- 20 `node:test` cases green; tsc + prettier clean.
- Verified end-to-end against elm-visualization on Netlify (via a vendored build of this exact code): clean build succeeds, all 37 examples render correctly (including the previously-broken WeatherRadial), and the index is correctly sorted — tested through the real `--ellie` path.